### PR TITLE
FIX gentoo

### DIFF
--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -19,11 +19,6 @@ if have_library('xml2', 'xmlNewDoc')
 
     # if found, enable direct calls to Nokogiri (and libxml2)
     $CFLAGS += ' -DNGLIB' if find_header('nokogiri.h', nokogiri_ext)
-    
-    if File.exists?("/etc/gentoo-release")
-      # link to the library to prevent: nokogumbo.c:(.text+0x26a): undefined reference to `Nokogiri_wrap_xml_document'
-      $LDFLAGS += " -L#{nokogiri_ext} -l:nokogiri.so"
-    end
   end
 end
 


### PR DESCRIPTION
Linking to nokogiri was failing due to a dedicated line for gentoo.